### PR TITLE
fix(nexus): timeout in fs

### DIFF
--- a/nexus/pkg/server/filestream.go
+++ b/nexus/pkg/server/filestream.go
@@ -159,8 +159,10 @@ func (fs *FileStream) doChunkProcess() {
 			}
 			fs.sendChunkList(chunkList)
 		case <-time.After(heartbeatTime):
-			fmt.Println("timeout")
-			fs.sendChunkList(chunkList)
+			if len(chunkList) > 0 {
+				fmt.Println("timeout")  // todo: remove
+				fs.sendChunkList(chunkList)
+			}
 		}
 	}
 }


### PR DESCRIPTION
If the training script does not do anything and just sleeps between log calls, time.After(heartbeatTime) would fire off and print "timeout" at 2s intervals.