### PR TITLE
test(sdk): fix filestream test issue and add race check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
           name: Run tests and collect coverage
           command: |
             cd nexus
-            go test -coverprofile=coverage.txt -covermode=atomic ./...
+            go test -race -coverprofile=coverage.txt -covermode=atomic ./...
       - codecov/upload
 
 workflows:

--- a/nexus/pkg/server/filestream.go
+++ b/nexus/pkg/server/filestream.go
@@ -95,12 +95,11 @@ type FileStream struct {
 
 // NewFileStream creates a new filestream
 func NewFileStream(path string, settings *service.Settings, logger *observability.NexusLogger) *FileStream {
-	retryClient := newRetryClient(settings.GetApiKey().GetValue(), logger)
 	fs := FileStream{
 		path:       path,
 		settings:   settings,
 		logger:     logger,
-		httpClient: retryClient,
+		httpClient: newRetryClient(settings.GetApiKey().GetValue(), logger),
 		recordWait: &sync.WaitGroup{},
 		chunkWait:  &sync.WaitGroup{},
 		replyWait:  &sync.WaitGroup{},
@@ -108,7 +107,6 @@ func NewFileStream(path string, settings *service.Settings, logger *observabilit
 		chunkChan:  make(chan chunkData, BufferSize),
 		replyChan:  make(chan map[string]interface{}, BufferSize),
 	}
-	fs.Start()
 	return &fs
 }
 

--- a/nexus/pkg/server/filestream_test.go
+++ b/nexus/pkg/server/filestream_test.go
@@ -142,7 +142,6 @@ func NewFilestreamTest(tName string, fn func(fs *server.FileStream)) *filestream
 	fs := server.NewFileStream(tserver.hserver.URL+fstreamPath, tserver.settings, tserver.logger)
 	fsTest := filestreamTest{capture: &capture, path: fstreamPath, mux: tserver.mux, fs: fs, tserver: tserver}
 	defer fsTest.finish()
-	fs.Start()
 	fn(fsTest.fs)
 	return &fsTest
 }

--- a/nexus/pkg/server/filestream_test.go
+++ b/nexus/pkg/server/filestream_test.go
@@ -140,6 +140,7 @@ func NewFilestreamTest(tName string, fn func(fs *server.FileStream)) *filestream
 	fstreamPath := "/test/" + tName
 	tserver.mux.Handle(fstreamPath, apiHandler{&capture})
 	fs := server.NewFileStream(tserver.hserver.URL+fstreamPath, tserver.settings, tserver.logger)
+	fs.Start()
 	fsTest := filestreamTest{capture: &capture, path: fstreamPath, mux: tserver.mux, fs: fs, tserver: tserver}
 	defer fsTest.finish()
 	fn(fsTest.fs)

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -146,6 +146,7 @@ func (s *Sender) sendRunStart(_ *service.RunStartRequest) {
 		fsPath := fmt.Sprintf("%s/files/%s/%s/%s/file_stream",
 			s.settings.GetBaseUrl().GetValue(), s.RunRecord.Entity, s.RunRecord.Project, s.RunRecord.RunId)
 		s.fileStream = NewFileStream(fsPath, s.settings, s.logger)
+		s.fileStream.Start()
 	}
 	s.uploader = uploader.NewUploader(s.ctx, s.logger)
 }


### PR DESCRIPTION
Add race checking which exposed an issue where the test was starting two filestream goroutines which were processing the same channels in parallel... oops