### PR TITLE
feat(nexus): add basic summary support

### DIFF
--- a/nexus/pkg/server/filestream.go
+++ b/nexus/pkg/server/filestream.go
@@ -18,6 +18,7 @@ import (
 const (
 	EventsFileName  = "wandb-events.jsonl"
 	HistoryFileName = "wandb-history.jsonl"
+	SummaryFileName = "wandb-summary.json"
 	OutputFileName  = "output.log"
 	maxItemsPerPush = 5_000
 	delayProcess    = 20 * time.Millisecond

--- a/nexus/pkg/server/filestream.go
+++ b/nexus/pkg/server/filestream.go
@@ -36,6 +36,7 @@ const (
 	historyChunk chunkFile = iota
 	outputChunk
 	eventsChunk
+	summaryChunk
 )
 
 type chunkData struct {
@@ -153,6 +154,8 @@ func (fs *FileStream) doRecordProcess(inChan <-chan *service.Record) {
 		switch x := record.RecordType.(type) {
 		case *service.Record_History:
 			fs.streamHistory(x.History)
+		case *service.Record_Summary:
+			fs.streamSummary(x.Summary)
 		case *service.Record_Stats:
 			fs.streamSystemMetrics(x.Stats)
 		case *service.Record_OutputRaw:
@@ -231,31 +234,55 @@ func (fs *FileStream) doReplyProcess(inChan <-chan map[string]interface{}) {
 	}
 }
 
-func (fs *FileStream) jsonifyHistory(record *service.HistoryRecord) string {
+type Item interface {
+	GetKey() string
+	GetValueJson() string
+}
+
+func jsonifyItems[V Item](items []V) (string, error) {
 	jsonMap := make(map[string]interface{})
 
-	for _, item := range record.Item {
+	for _, item := range items {
 		var value interface{}
-		if err := json.Unmarshal([]byte(item.ValueJson), &value); err != nil {
+		if err := json.Unmarshal([]byte(item.GetValueJson()), &value); err != nil {
 			e := fmt.Errorf("json unmarshal error: %v, items: %v", err, item)
-			fs.logger.CaptureFatalAndPanic("json unmarshal error", e)
+			return "", e
 		}
-		jsonMap[item.Key] = value
+		jsonMap[item.GetKey()] = value
 	}
 
 	jsonBytes, err := json.Marshal(jsonMap)
 	if err != nil {
-		fs.logger.CaptureFatalAndPanic("json unmarshal error", err)
+		return "", err
 	}
-	return string(jsonBytes)
+	return string(jsonBytes), nil
 }
 
 func (fs *FileStream) streamHistory(msg *service.HistoryRecord) {
+	line, err := jsonifyItems(msg.Item)
+	if err != nil {
+		fs.logger.CaptureFatalAndPanic("json unmarshal error", err)
+	}
 	chunk := chunkData{
 		fileName: HistoryFileName,
 		fileData: &chunkLine{
 			chunkType: historyChunk,
-			line:      fs.jsonifyHistory(msg),
+			line:      line,
+		},
+	}
+	fs.pushChunk(chunk)
+}
+
+func (fs *FileStream) streamSummary(msg *service.SummaryRecord) {
+	line, err := jsonifyItems(msg.Update)
+	if err != nil {
+		fs.logger.CaptureFatalAndPanic("json unmarshal error", err)
+	}
+	chunk := chunkData{
+		fileName: SummaryFileName,
+		fileData: &chunkLine{
+			chunkType: summaryChunk,
+			line:      line,
 		},
 	}
 	fs.pushChunk(chunk)

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -410,7 +410,7 @@ func (h *Handler) updateSummary(history *service.HistoryRecord) {
 		h.summary[historyItems[i].Key] = historyItems[i].ValueJson
 		summaryItems = append(summaryItems,
 			&service.SummaryItem{
-				Key: historyItems[i].Key,
+				Key:       historyItems[i].Key,
 				ValueJson: historyItems[i].ValueJson})
 	}
 

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -399,13 +399,29 @@ func (h *Handler) handlePartialHistory(_ *service.Record, request *service.Parti
 }
 
 func (h *Handler) updateSummary(history *service.HistoryRecord) {
+	var summaryItems []*service.SummaryItem
 	if h.summary == nil {
+		// TODO(memory): persist this in the future as it will grow with number of distinct keys
 		h.summary = make(map[string]string)
 	}
-	items := history.Item
-	for i := 0; i < len(items); i++ {
-		h.summary[items[i].Key] = items[i].ValueJson
+
+	historyItems := history.Item
+	for i := 0; i < len(historyItems); i++ {
+		h.summary[historyItems[i].Key] = historyItems[i].ValueJson
+		summaryItems = append(summaryItems,
+			&service.SummaryItem{
+				Key: historyItems[i].Key,
+				ValueJson: historyItems[i].ValueJson})
 	}
+
+	rec := &service.Record{
+		RecordType: &service.Record_Summary{
+			Summary: &service.SummaryRecord{
+				Update: summaryItems,
+			},
+		},
+	}
+	h.sendRecord(rec)
 }
 
 func (h *Handler) GetRun() *service.RunRecord {

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -310,6 +310,7 @@ func (s *Sender) sendHistory(record *service.Record, _ *service.HistoryRecord) {
 func (s *Sender) sendSummary(_ *service.Record, summary *service.SummaryRecord) {
 	// TODO(network): buffer summary sending for network efficiency until we can send only updates
 	// TODO(compat): handle deletes, nested keys
+	// TODO(compat): write summary file
 
 	// track each key in the in memory summary store
 	// TODO(memory): avoid keeping summary for all distinct keys

--- a/nexus/pkg/server/sender.go
+++ b/nexus/pkg/server/sender.go
@@ -106,6 +106,8 @@ func (s *Sender) sendRecord(record *service.Record) {
 		s.sendFiles(record, x.Files)
 	case *service.Record_History:
 		s.sendHistory(record, x.History)
+	case *service.Record_Summary:
+		s.sendSummary(record, x.Summary)
 	case *service.Record_Stats:
 		s.sendSystemMetrics(record, x.Stats)
 	case *service.Record_OutputRaw:
@@ -296,6 +298,13 @@ func (s *Sender) sendRun(record *service.Record, run *service.RunRecord) {
 // sendHistory sends a history record to the file stream,
 // which will then send it to the server
 func (s *Sender) sendHistory(record *service.Record, _ *service.HistoryRecord) {
+	if s.fileStream != nil {
+		s.fileStream.StreamRecord(record)
+	}
+}
+
+func (s *Sender) sendSummary(record *service.Record, _ *service.SummaryRecord) {
+	// TODO(network): buffer summary sending for network efficiency until we can send only updates
 	if s.fileStream != nil {
 		s.fileStream.StreamRecord(record)
 	}


### PR DESCRIPTION
Basic summary support added
3 sets of TODOs added:
- memory: this has unnecessary memory growth (no worse than current wandb/wandb)
- compat: need changes to hit wandb/wandb compatibility
- network: suboptimal network usage - worse than current wandb/wandb

Also there are no tests. should be added when compat and network issues are addressed.
memory issue the tentative plan is to introduce a sqlite db for active runs.   This could help for a bunch of features in the future in addition to artifact cache implementation work