### PR TITLE
fix(nexus): pass exitcode on server teardown

### DIFF
--- a/nexus/pkg/server/connection.go
+++ b/nexus/pkg/server/connection.go
@@ -255,15 +255,15 @@ func (nc *Connection) handleInformFinish(msg *service.ServerInformFinishRequest)
 	if stream, err := streamMux.RemoveStream(streamId); err != nil {
 		slog.Error("handleInformFinish:", "err", err, "streamId", streamId, "id", nc.id)
 	} else {
-		stream.Close(false)
+		stream.Close()
 	}
 }
 
 // handleInformTeardown is called when the client sends a teardown message
 // for the entire server session
-func (nc *Connection) handleInformTeardown(_ *service.ServerInformTeardownRequest) {
+func (nc *Connection) handleInformTeardown(teardown *service.ServerInformTeardownRequest) {
 	slog.Debug("handle teardown received", "id", nc.id)
 	close(nc.teardownChan)
-	streamMux.CloseAllStreams(true) // TODO: this seems wrong to Close all streams from a single connection
+	streamMux.FinishAndCloseAllStreams(teardown.ExitCode)
 	nc.Close()
 }

--- a/nexus/pkg/server/stream.go
+++ b/nexus/pkg/server/stream.go
@@ -216,7 +216,7 @@ func (s *Stream) FinishAndClose(exitCode int32) {
 			Exit: &service.RunExitRecord{
 				ExitCode: exitCode,
 			}},
-		Control:    &service.Control{AlwaysSend: true},
+		Control: &service.Control{AlwaysSend: true},
 	}
 	s.HandleRecord(record)
 

--- a/nexus/pkg/server/stream.go
+++ b/nexus/pkg/server/stream.go
@@ -203,20 +203,26 @@ func (s *Stream) GetRun() *service.RunRecord {
 //
 // This will finish the Stream's wait group, which will allow the stream to be
 // garbage collected.
-func (s *Stream) Close(force bool) {
-	// send exit record to handler
-	if force {
-		record := &service.Record{
-			RecordType: &service.Record_Exit{Exit: &service.RunExitRecord{}},
-			Control:    &service.Control{AlwaysSend: true},
-		}
-		s.HandleRecord(record)
-	}
+func (s *Stream) Close() {
+	// Close and wait for input channel to shutdown
 	close(s.inChan)
 	s.wg.Wait()
-	if force {
-		s.PrintFooter()
+}
+
+func (s *Stream) FinishAndClose(exitCode int32) {
+	// send exit record to handler
+	record := &service.Record{
+		RecordType: &service.Record_Exit{
+			Exit: &service.RunExitRecord{
+				ExitCode: exitCode,
+			}},
+		Control:    &service.Control{AlwaysSend: true},
 	}
+	s.HandleRecord(record)
+
+	s.Close()
+
+	s.PrintFooter()
 	s.logger.Info("closed stream", "id", s.settings.RunId)
 }
 

--- a/nexus/pkg/server/stream_mux.go
+++ b/nexus/pkg/server/stream_mux.go
@@ -58,8 +58,8 @@ func (sm *StreamMux) RemoveStream(streamId string) (*Stream, error) {
 	}
 }
 
-// CloseAllStreams closes all streams in the mux.
-func (sm *StreamMux) CloseAllStreams(force bool) {
+// FinishAndCloseAllStreams closes all streams in the mux.
+func (sm *StreamMux) FinishAndCloseAllStreams(exitCode int32) {
 	sm.mutex.RLock()
 	defer sm.mutex.RUnlock()
 
@@ -67,7 +67,7 @@ func (sm *StreamMux) CloseAllStreams(force bool) {
 	for streamId, stream := range sm.mux {
 		wg.Add(1)
 		go func(stream *Stream) {
-			stream.Close(force)
+			stream.FinishAndClose(exitCode)
 			wg.Done()
 		}(stream)
 		// delete all streams from mux


### PR DESCRIPTION
teardown signals the exit of the user process so it should propagate an exit to streams that have not been finished yet

it is normal for teardown to shutdown all the streams, because at the point where teardown is called, there should be no more stream activity (the main user process is shutting down). This is the implicit finish functionality and will happen for any runs that did not have explicit run.finish() calls.

In the future if the wandb server satisfies multiple user processes, the teardown should shutdown only streams created by this user process. (see the hackweek "clI" for wandb service for what this could look like)