### PR TITLE
fix(nexus): increase connection buffer to handle large messages

### DIFF
--- a/nexus/pkg/server/connection.go
+++ b/nexus/pkg/server/connection.go
@@ -16,7 +16,10 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-const maxScanSize = 1024 * 1024 // 1MB buffer size for connection reads
+const (
+	messageSize    = 1024 * 1024      // 1MB message size
+	maxMessageSize = 64 * 1024 * 1024 // 64MB max message size
+)
 
 // Connection is the connection for a stream.
 // It is a wrapper around the underlying connection
@@ -113,8 +116,8 @@ func (nc *Connection) Respond(resp *service.ServerResponse) {
 // it closes the inChan when the connection is closed
 func (nc *Connection) readConnection() {
 	scanner := bufio.NewScanner(nc.conn)
-	buf := make([]byte, maxScanSize)
-	scanner.Buffer(buf, maxScanSize)
+	buf := make([]byte, messageSize)
+	scanner.Buffer(buf, maxMessageSize)
 	tokenizer := &Tokenizer{}
 	scanner.Split(tokenizer.split)
 	for scanner.Scan() {

--- a/nexus/pkg/server/connection.go
+++ b/nexus/pkg/server/connection.go
@@ -16,7 +16,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
-const connSize = 1024 * 1024 // 1MB buffer size for connection reads
+const maxScanSize = 1024 * 1024 // 1MB buffer size for connection reads
 
 // Connection is the connection for a stream.
 // It is a wrapper around the underlying connection
@@ -113,8 +113,8 @@ func (nc *Connection) Respond(resp *service.ServerResponse) {
 // it closes the inChan when the connection is closed
 func (nc *Connection) readConnection() {
 	scanner := bufio.NewScanner(nc.conn)
-	buf := make([]byte, connSize)
-	scanner.Buffer(buf, connSize)
+	buf := make([]byte, maxScanSize)
+	scanner.Buffer(buf, maxScanSize)
 	tokenizer := &Tokenizer{}
 	scanner.Split(tokenizer.split)
 	for scanner.Scan() {

--- a/nexus/pkg/server/connection.go
+++ b/nexus/pkg/server/connection.go
@@ -108,6 +108,8 @@ func (nc *Connection) HandleConnection() {
 		nc.handleServerResponse()
 		nc.wg.Done()
 	}()
+
+	nc.wg.Wait()
 }
 
 func (nc *Connection) Close() {
@@ -115,7 +117,6 @@ func (nc *Connection) Close() {
 	if err := nc.conn.Close(); err != nil {
 		slog.Error("error closing connection", "err", err, "id", nc.id)
 	}
-	nc.wg.Wait()
 	slog.Info("closed connection", "id", nc.id)
 }
 

--- a/nexus/pkg/server/handler.go
+++ b/nexus/pkg/server/handler.go
@@ -110,7 +110,8 @@ func (h *Handler) sendRecord(record *service.Record) {
 
 //gocyclo:ignore
 func (h *Handler) handleRecord(record *service.Record) {
-	h.logger.Debug("handle: got a message", "record", record)
+	recordType := record.GetRecordType()
+	h.logger.Debug("handle: got a message", "record_type", recordType)
 	switch x := record.RecordType.(type) {
 	case *service.Record_Alert:
 		h.handleAlert(record)


### PR DESCRIPTION
- moved logic that reads from the connection back the nexus connection
- increased the scanner buffer from default 64K to 1M <- what is the max value we want to support?
- add more comments in the connection file 